### PR TITLE
Don't generate link if params contain undefined

### DIFF
--- a/addon/helpers/href-to.js
+++ b/addon/helpers/href-to.js
@@ -42,6 +42,10 @@ export function hrefTo(params) {
     appNeedsClickHandler = false;
   }
 
+  if(params.contains(undefined)) {
+    return;
+  }
+
   var lastParam = params[params.length - 1];
 
   var queryParams = {};


### PR DESCRIPTION
Hey,

I just tried this in my app and noticed it's trying to invoke serialize() on my routes (through the router) even for undefined models - unlike link-to. So to make it a "more drop-in" solution I'm proposing to adopt that behavior. I'm not completely sure this is the perfect place to handle this, especially with queryParams - but as I don't really use queryParams in my app, it's hard for me to verify if this makes any sense.

Anyway this is what I could come up with in 2min looking at it and it made my application work, so I thought I'd share :-)


BR,
Dominik