### PR TITLE
Remove deprecation warnings in newer Ember versions

### DIFF
--- a/addon/helpers/href-to.js
+++ b/addon/helpers/href-to.js
@@ -1,8 +1,9 @@
 import Em from 'ember';
+import getOwner from 'ember-getowner-polyfill';
 
 export default Em.Helper.extend({
   compute(params) {
-    let router = this.container.lookup('router:main');
+    let router = getOwner(this).lookup('router:main');
     if(router === undefined || router.router === undefined) {
       return;
     }

--- a/app/instance-initializers/ember-href-to.js
+++ b/app/instance-initializers/ember-href-to.js
@@ -8,10 +8,15 @@ function _getNormalisedRootUrl(router) {
   return rootURL;
 }
 
+function _lookupRouter(applicationInstance) {
+  const container = 'lookup' in applicationInstance ? applicationInstance : applicationInstance.container;
+  return container.lookup('router:main');
+}
+
 export default {
   name: 'ember-href-to',
   initialize: function(applicationInstance) {
-    let router = applicationInstance.container.lookup('router:main');
+    let router = _lookupRouter(applicationInstance);
     let rootURL = _getNormalisedRootUrl(router);
     let $body = Em.$(document.body);
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "ember-addon"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.0.0"
+    "ember-cli-babel": "^5.0.0",
+    "ember-getowner-polyfill": "^1.0.1"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
This PR removes two deprecations:
- [ember-applicationinstance-container](http://emberjs.com/deprecations/v2.x/#toc_ember-applicationinstance-container) showing up in Ember >= 2
- [injected-container-access](http://emberjs.com/deprecations/v2.x/#toc_injected-container-access) showing up in Ember >= 2.3

"ember try:testall" is passing.

Cheers!