### PR TITLE
Replace most jQuery methods

### DIFF
--- a/app/instance-initializers/ember-href-to.js
+++ b/app/instance-initializers/ember-href-to.js
@@ -1,5 +1,15 @@
 import Em from 'ember';
 
+// http://james.padolsey.com/jquery/#v=2.1.3&fn=jQuery.fn.hasClass
+function _hasClass(element, selector) {
+  const className = " " + selector + " ";
+  const rclass = /[\t\r\n\f]/g;
+  if (element.nodeType === 1 && (" " + element.className + " ").replace(rclass, " ").indexOf(className) >= 0) {
+      return true;
+  }
+  return false;
+}
+
 function _getNormalisedRootUrl(router) {
   let rootURL = router.rootURL;
   if(rootURL.charAt(rootURL.length - 1) !== '/') {
@@ -11,17 +21,17 @@ function _getNormalisedRootUrl(router) {
 export default {
   name: 'ember-href-to',
   initialize: function(applicationInstance) {
-    let router = applicationInstance.container.lookup('router:main');
-    let rootURL = _getNormalisedRootUrl(router);
-    let $body = Em.$(document.body);
+    const router = applicationInstance.container.lookup('router:main');
+    const rootURL = _getNormalisedRootUrl(router);
+    const $body = Em.$(document.body);
 
     $body.off('click.href-to', 'a');
     $body.on('click.href-to', 'a', function(e) {
-      let $target = Em.$(e.currentTarget);
-      let handleClick = (e.which === 1 && !e.ctrlKey && !e.metaKey);
+      const target = e.currentTarget;
+      const handleClick = (e.which === 1 && !e.ctrlKey && !e.metaKey);
 
-      if(handleClick && !$target.hasClass('ember-view') && Em.isNone($target.attr('data-ember-action'))) {
-        let url = $target.attr('href');
+      if(handleClick && !_hasClass(target, 'ember-view') && Em.isNone(target.getAttribute('data-ember-action'))) {
+        let url = target.getAttribute('href');
 
         if(url && url.indexOf(rootURL) === 0) {
           url = url.substr(rootURL.length - 1);


### PR DESCRIPTION
A work in progress to replace jQuery. See https://github.com/intercom/ember-href-to/issues/2

I had to polyfill classList but perhaps this is where jQuery should be kept? Same with the click events.