### PR TITLE
Let events bubble up through DOM

### DIFF
--- a/app/instance-initializers/browser/ember-href-to.js
+++ b/app/instance-initializers/browser/ember-href-to.js
@@ -34,7 +34,7 @@ export default {
           if(router.router.recognizer.recognize(url)) {
             router.handleURL(url);
             router.router.updateURL(url);
-            return false;
+            e.preventDefault();
           }
         }
       }

--- a/tests/integration/href-to-test.js
+++ b/tests/integration/href-to-test.js
@@ -81,3 +81,14 @@ test('clicking an action works', function(assert) {
     assert.equal($('#count').text(), '1');
   });
 });
+
+test('clicking a href-to to should propagate events and prevent default ', function(assert) {
+  visit('/');
+  andThen(function() {
+    let event = Em.$.Event('click', { which: 1 });
+    let element = findWithAssert('#href-to-links a:contains(About)');
+    element.trigger(event);
+    assert.equal(event.isDefaultPrevented(), true, 'should prevent default');
+    assert.equal(event.isPropagationStopped(), false, 'should not stop propagation');
+  });
+});


### PR DESCRIPTION
Instead of returning `false` which will both `stopPropagation()` and `preventDefault()` this will let events bubble up and `href-to`-links will behave the same way `link-to` does per default.

Checkout ember.js `link-to`-source: https://github.com/emberjs/ember.js/blob/master/packages/ember-htmlbars/lib/components/link-to.js#L627

> Some context: I'm using `ember-modal-dialog` in a project and it listens for events outside the modal in order to dismiss and close it. This PR enables the click event to bubble up and for ember-modal-dialog to do its thing :)