### PR TITLE
Fix Integration: Recognize clicks from components that use href-to (ember-paper)

### DIFF
--- a/app/instance-initializers/browser/ember-href-to.js
+++ b/app/instance-initializers/browser/ember-href-to.js
@@ -25,7 +25,15 @@ export default {
       let $target = Em.$(e.currentTarget);
       let handleClick = (e.which === 1 && !e.ctrlKey && !e.metaKey);
 
-      if(handleClick && !$target.hasClass('ember-view') && Em.isNone($target.attr('data-ember-action'))) {
+      if( handleClick && Em.isNone( $target.attr('data-ember-action') )
+          && (
+            !$target.hasClass('ember-view')
+            || (
+              $target.hasClass('href-to')
+              && Em.isPresent($target.attr('href'))
+            )
+          )
+        ) {
         let url = $target.attr('href');
 
         if(url && url.indexOf(rootURL) === 0) {


### PR DESCRIPTION
I want to use href-to with a component from https://github.com/miguelcobain/ember-paper that renders an anchor element.

`{{#paper-button href=(href-to "settings") class="href-to"}}Settings{{/paper-button}}`

I am able to use the href-to helper to set the `href` attribute on the component, which renders as expected.  Great!

```
<a id="ember736" tabindex="0" href="/settings" class="href-to ember-view paper-button md-default-theme md-button md-ink-ripple">  Settings
<div class="md-ripple-container"></div></a>
```

But with this, href-to didn't recognize when I clicked the link.  I got the hard native browser redirect rather than a nice Ember router transition.  It was because every component's element gets the `.ember-view` class which didn't fit the conditions in href-to's initializer.

So I made this pull request to update the initializer.  Now href-to recognizes and smoothly transitions clicks on anchor elements when they have the `.href-to` class even if they are components. 

To stay out of the way, href-to continues to not intervene when there is an action set on an element.
