### PR TITLE
Links with a download attribute must be ignored

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ before_install:
   - export PATH=/usr/local/phantomjs-2.0.0/bin:$PATH
   - "npm config set spin false"
   - "npm install -g npm@^3"
+  - "npm install -g phantomjs-prebuilt@2"
 
 install:
   - npm install -g bower

--- a/app/instance-initializers/browser/ember-href-to.js
+++ b/app/instance-initializers/browser/ember-href-to.js
@@ -13,6 +13,15 @@ function _lookupRouter(applicationInstance) {
   return container.lookup('router:main');
 }
 
+export function canHandle(e) {
+  let $target = Em.$(e.currentTarget);
+  let handleClick = (e.which === 1 && !e.ctrlKey && !e.metaKey);
+  return handleClick &&
+    !$target.hasClass('ember-view') &&
+    Em.isNone($target.attr('data-ember-action')) &&
+    $target.attr('download') === undefined;
+}
+
 export default {
   name: 'ember-href-to',
   initialize: function(applicationInstance) {
@@ -22,10 +31,8 @@ export default {
 
     $body.off('click.href-to', 'a');
     $body.on('click.href-to', 'a', function(e) {
-      let $target = Em.$(e.currentTarget);
-      let handleClick = (e.which === 1 && !e.ctrlKey && !e.metaKey);
-
-      if(handleClick && !$target.hasClass('ember-view') && Em.isNone($target.attr('data-ember-action'))) {
+      if(canHandle(e)) {
+        let $target = Em.$(e.currentTarget);
         let url = $target.attr('href');
 
         if(url && url.indexOf(rootURL) === 0) {

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -19,6 +19,7 @@
   [<a href="{{href-to 'pages.second'}}"><span id="inner-span">Second Page (with inner span)</span></a>]
   [<a>An anchor with no href</a>]
   [<a href="http://localhost:4200/about">An anchor with an absolute href</a>]
+  [<a href="/about" download>An anchor with a download attribute</a>]
 </div>
 <hr />
 

--- a/tests/unit/instance-initializers/browser/ember-href-to-test.js
+++ b/tests/unit/instance-initializers/browser/ember-href-to-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { canHandle } from '../../../../instance-initializers/browser/ember-href-to';
+
+module('Unit | Instance Initializer | browser/ember-href-to#canHandle');
+
+test('returns false for events on links with a download attribute', function(assert) {
+  let anchor = document.createElement('a');
+  anchor.href = '/file.pdf';
+  anchor.download = '';
+  let event = { currentTarget: anchor, which: 1, ctrlKey: false, metaKey: false };
+  assert.equal(canHandle(event), false);
+});


### PR DESCRIPTION
At the moment this addon is wrongly trying to interfere with this link `<a href="/report/year.pdf" download>Download report</a>`.

Links marked as download should be completely ignored.