### PR TITLE
point out works with fragment identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This is an Ember CLI addon, to install:
 <a href="{{href-to 'contacts.contact' contact}}">View Contact 1</a>
 <a href="{{href-to 'contacts.contact' 2}}">View Contact 2</a>
 <a href="{{href-to 'contact-us' (query-params section='first')}}">You can also use query params</a>
+<a href="{{href-to 'contact-us'}}#first">You can also use fragment identifiers</a>
 <a href="{{href-to 'contact-us'}}" data-href-to-ignore>
   If you have a catchall route (this.route('catchall', { path: "/*" })),
   you need to add the attribute "data-href-to-ignore",


### PR DESCRIPTION
since it doesn't work in {{link-to}} yet.