### PR TITLE
extract urlFor function so that it can be used directly

### DIFF
--- a/addon/helpers/href-to.js
+++ b/addon/helpers/href-to.js
@@ -1,24 +1,31 @@
 import Em from 'ember';
 import getOwner from 'ember-getowner-polyfill';
 
+function hrefTo(context, targetRouteName, ...rest) {
+  console.log('GJ: hrefTo', arguments);
+  let router = getOwner(context).lookup('router:main');
+  if (router === undefined || router.router === undefined) {
+    return;
+  }
+
+  let lastParam = rest[rest.length - 1];
+
+  let queryParams = {};
+  if (lastParam && lastParam.isQueryParams) {
+    queryParams = rest.pop();
+  }
+
+  let args = [targetRouteName];
+  args.push.apply(args, rest);
+  args.push({ queryParams: queryParams.values });
+
+  return router.generate.apply(router, args);
+}
+
+export { hrefTo };
+
 export default Em.Helper.extend({
   compute([targetRouteName, ...rest]) {
-    let router = getOwner(this).lookup('router:main');
-    if (router === undefined || router.router === undefined) {
-      return;
-    }
-
-    let lastParam = rest[rest.length - 1];
-
-    let queryParams = {};
-    if (lastParam && lastParam.isQueryParams) {
-      queryParams = rest.pop();
-    }
-
-    let args = [targetRouteName];
-    args.push.apply(args, rest);
-    args.push({ queryParams: queryParams.values });
-
-    return router.generate.apply(router, args);
+    return hrefTo(this, targetRouteName, ...rest);
   }
 });


### PR DESCRIPTION
The `urlFor` function was [previously exported](https://github.com/intercom/ember-href-to/blob/master/app/helpers/href-to.js#L1), but this was lost in a previous refactor. This brings it back