### PR TITLE
fix ember-getowner-polyfill deprication

### DIFF
--- a/addon/helpers/href-to.js
+++ b/addon/helpers/href-to.js
@@ -1,5 +1,6 @@
 import Em from 'ember';
-import getOwner from 'ember-getowner-polyfill';
+
+const { getOwner } = Em;
 
 function hrefTo(context, targetRouteName, ...rest) {
   let router = getOwner(context).lookup('router:main');

--- a/package.json
+++ b/package.json
@@ -45,8 +45,7 @@
     "ember-addon"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.6",
-    "ember-getowner-polyfill": "^1.0.1"
+    "ember-cli-babel": "^5.1.6"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
Fix for deprecation: 
```
ember-getowner-polyfill is now a true polyfill. Use Ember.getOwner directly instead of importing from ember-getowner-polyfill [deprecation id: ember-getowner-polyfill.import]
```