### PR TITLE
Add target='_blank' check to shouldHandle

### DIFF
--- a/addon/href-to.js
+++ b/addon/href-to.js
@@ -18,6 +18,7 @@ export default class {
   shouldHandle() {
     return this.isUnmodifiedLeftClick() &&
       this.isNotIgnored() &&
+      this.hasNoTargetBlank() &&
       this.hasNoActionHelper() &&
       this.hasNoDownload() &&
       this.isNotLinkComponent() &&
@@ -37,6 +38,10 @@ export default class {
     let e = this.event;
 
     return (e.which === undefined || e.which === 1) && !e.ctrlKey && !e.metaKey;
+  }
+
+  hasNoTargetBlank() {
+    return this.target.attr('target') !== '_blank';
   }
 
   isNotIgnored() {

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -20,6 +20,7 @@
   [<a>An anchor with no href</a>]
   [<a href="http://localhost:4200/about">An anchor with an absolute href</a>]
   [<a href="/about" download>An anchor with a download attribute</a>]
+  [<a href="/about" target="_blank">An anchor with a target blank</a>]
   [{{#link-button href=(href-to 'about')}}A component with a bound href{{/link-button}}]
 </div>
 <hr />

--- a/tests/unit/href-to-test.js
+++ b/tests/unit/href-to-test.js
@@ -83,6 +83,20 @@ test('#hasNoDownload should be true if [download] is not present', function(asse
   assert.ok(hrefTo.hasNoDownload());
 });
 
+test('#hasNoTargetBlank should be false if [target="_blank"] is present', function(assert) {
+  let event = getClickEventOnEl("<a href='' target='_blank'>");
+  let hrefTo = createHrefToForEvent(event);
+
+  assert.notOk(hrefTo.hasNoTargetBlank());
+});
+
+test('#hasNoTargetBlank should be true if [target="_blank"] is not present', function(assert) {
+  let event = getClickEventOnEl("<a href=''>");
+  let hrefTo = createHrefToForEvent(event);
+
+  assert.ok(hrefTo.hasNoTargetBlank());
+});
+
 test('#getUrlWithoutRoot should remove the rootUrl', function(assert) {
   let event = getClickEventOnEl("<a href='/a/inbox'>");
   let hrefTo = createHrefToForEvent(event);


### PR DESCRIPTION
Prevents the ember-href-to instance-initializer from handling native 'A' tags with the target="_blank" attribute present.