### PR TITLE
support `params` argument

### DIFF
--- a/addon/helpers/href-to.js
+++ b/addon/helpers/href-to.js
@@ -25,7 +25,11 @@ function hrefTo(context, targetRouteName, ...rest) {
 export { hrefTo };
 
 export default Em.Helper.extend({
-  compute([targetRouteName, ...rest]) {
-    return hrefTo(this, targetRouteName, ...rest);
+  compute([targetRouteName, ...rest], namedArgs) {
+    if(namedArgs.params) {
+      return hrefTo(this, ...namedArgs.params);
+    } else {
+      return hrefTo(this, targetRouteName, ...rest);
+    }
   }
 });

--- a/tests/acceptance/href-to-test.js
+++ b/tests/acceptance/href-to-test.js
@@ -30,6 +30,14 @@ test('clicking a simple href-to', function(assert) {
   });
 });
 
+test('clicking a href-to with a params argument', function(assert) {
+  visit('/');
+  leftClick('#href-to-links a:contains(Second Page (with dynamic params))');
+  andThen(function() {
+    assert.equal(currentURL(), '/pages/second');
+  });
+});
+
 test('clicking a href-to with an inner element', function(assert) {
   visit('/');
   leftClick('#inner-span');

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -1,0 +1,5 @@
+import Em from 'ember';
+
+export default Em.Controller.extend({
+  dynamicParams: ['pages.second']
+});

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -7,6 +7,7 @@
   [{{#link-to 'about'}}About{{/link-to}}]
   [{{#link-to 'pages.first'}}First Page{{/link-to}}]
   [{{#link-to 'pages.second'}}Second Page{{/link-to}}]
+  [{{#link-to params=dynamicParams}}Second Page (with dynamic params){{/link-to}}]
 </div>
 <br />
 
@@ -16,6 +17,7 @@
   [<a href="{{href-to 'about'}}">About</a>]
   [<a href="{{href-to 'pages.first'}}">First Page</a>]
   [<a href="{{href-to 'pages.second'}}">Second Page</a>]
+  [<a href="{{href-to params=dynamicParams}}">Second Page (with dynamic params)</a>]
   [<a href="{{href-to 'pages.second'}}"><span id="inner-span">Second Page (with inner span)</span></a>]
   [<a>An anchor with no href</a>]
   [<a href="http://localhost:4200/about">An anchor with an absolute href</a>]


### PR DESCRIPTION
This adds support for a `params` argument which `link-to` supports:

```js
{{#link-to params=dynamicParams}}click me{{/link-to}}
```

```js
<a href="{{href-to params=dynamicParams}}">click me</a>
```