### PR TITLE
Use _routerMicrolib instead of router when available

### DIFF
--- a/addon/helpers/href-to.js
+++ b/addon/helpers/href-to.js
@@ -4,7 +4,8 @@ const { getOwner } = Em;
 
 function hrefTo(context, targetRouteName, ...rest) {
   let router = getOwner(context).lookup('router:main');
-  if (router === undefined || router.router === undefined) {
+  if (router === undefined ||
+      (router._routerMicrolib === undefined && router.router === undefined)) {
     return;
   }
 

--- a/addon/href-to.js
+++ b/addon/href-to.js
@@ -29,9 +29,10 @@ export default class {
   handle() {
     let router = this._getRouter();
     let urlWithoutRoot = this.getUrlWithoutRoot();
+    let routerMicrolib = router._routerMicrolib || router.router;
 
     router.handleURL(urlWithoutRoot);
-    router.router.updateURL(urlWithoutRoot);
+    routerMicrolib.updateURL(urlWithoutRoot);
     this.event.preventDefault();
   }
 
@@ -78,8 +79,9 @@ export default class {
       let rootUrl = this._getRootUrl();
       let isInternal = url.indexOf(rootUrl) === 0;
       let urlWithoutRoot = this.getUrlWithoutRoot();
+      let routerMicrolib = router._routerMicrolib || router.router;
 
-      didRecognize = isInternal && router.router.recognizer.recognize(urlWithoutRoot);
+      didRecognize = isInternal && routerMicrolib.recognizer.recognize(urlWithoutRoot);
     }
 
     return didRecognize;


### PR DESCRIPTION
Closes #76.

There will be [case](https://github.com/kolybasov/ember-href-to/blob/79c33ce1bf0643b910c22bc915c0448a4afad9f3/addon/helpers/href-to.js#L7-L8) when deprecation rises. When `router._routerMicrolib` is undefined and Ember version is >= 2.13.0. Because we need to check if `router.router` instance is available to save compatibility with previous Ember versions.
In normal cases there should not be any deprecations.

Also `ember-canary` is now broken, but it is not because of this PR I believe.