### PR TITLE
Use router service polyfill

### DIFF
--- a/addon/helpers/href-to.js
+++ b/addon/helpers/href-to.js
@@ -2,9 +2,9 @@ import Helper from '@ember/component/helper';
 import { getOwner } from '@ember/application';
 
 function hrefTo(context, targetRouteName, ...rest) {
-  let router = getOwner(context).lookup('router:main');
-  if (router === undefined ||
-      (router._routerMicrolib === undefined && router.router === undefined)) {
+  let router = getOwner(context).lookup('service:router');
+
+  if(router === undefined) {
     return;
   }
 
@@ -19,7 +19,7 @@ function hrefTo(context, targetRouteName, ...rest) {
   args.push.apply(args, rest);
   args.push({ queryParams: queryParams.values });
 
-  return router.generate.apply(router, args);
+  return router.urlFor.apply(router, args);
 }
 
 export { hrefTo };

--- a/addon/href-to.js
+++ b/addon/href-to.js
@@ -28,11 +28,7 @@ export default class {
 
   handle() {
     let router = this._getRouter();
-    let urlWithoutRoot = this.getUrlWithoutRoot();
-    let routerMicrolib = router._routerMicrolib || router.router;
-
-    router.handleURL(urlWithoutRoot);
-    routerMicrolib.updateURL(urlWithoutRoot);
+    router.transitionTo(this.url);
     this.event.preventDefault();
   }
 
@@ -63,7 +59,7 @@ export default class {
     let isLinkComponent = false;
     let id = this.target.id;
     if (id) {
-      let componentInstance = this._getContainer(this.applicationInstance).lookup('-view-registry:main')[id];
+      let componentInstance = this.applicationInstance.lookup('-view-registry:main')[id];
       isLinkComponent = componentInstance && componentInstance instanceof LinkComponent;
     }
 
@@ -75,11 +71,11 @@ export default class {
     let didRecognize = false;
 
     if (url) {
-      let router = this._getContainer().lookup('router:main');
+      let router = this._getRouter();
       let rootUrl = this._getRootUrl();
       let isInternal = url.indexOf(rootUrl) === 0;
       let urlWithoutRoot = this.getUrlWithoutRoot();
-      let routerMicrolib = router._routerMicrolib || router.router;
+      let routerMicrolib = router._router._routerMicrolib || router._router.router;
 
       didRecognize = isInternal && routerMicrolib.recognizer.recognize(urlWithoutRoot);
     }
@@ -94,16 +90,12 @@ export default class {
   }
 
   _getRouter() {
-    return this._getContainer().lookup('router:main');
-  }
-
-  _getContainer() {
-    return 'lookup' in this.applicationInstance ? this.applicationInstance : this.applicationInstance.container;
+    return this.applicationInstance.lookup('service:router');
   }
 
   _getRootUrl() {
     let router = this._getRouter();
-    let rootURL = router.rootURL;
+    let rootURL = router.get('rootURL');
 
     if (rootURL.charAt(rootURL.length - 1) !== '/') {
       rootURL = rootURL + '/';

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "ember-addon"
   ],
   "dependencies": {
-    "ember-cli-babel": "^6.8.2"
+    "ember-cli-babel": "^6.8.2",
+    "ember-router-service-polyfill": "^1.0.2"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/tests/integration/component-test.js
+++ b/tests/integration/component-test.js
@@ -1,8 +1,13 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import { getOwner } from '@ember/application';
 
 moduleForComponent('component-with-a-link', 'Integration | Component | component-with-a-link', {
-  integration: true
+  integration: true,
+
+  beforeEach() {
+    getOwner(this).lookup('router:main').setupRouter();
+  }
 });
 
 test('should change colors', function(assert) {

--- a/tests/integration/href-to-test.js
+++ b/tests/integration/href-to-test.js
@@ -1,9 +1,14 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import HrefTo from 'ember-href-to/href-to';
+import { getOwner } from '@ember/application';
 
 moduleForComponent('a-link', 'Integration | HrefTo', {
-  integration: true
+  integration: true,
+
+  beforeEach() {
+    getOwner(this).lookup('router:main').setupRouter();
+  }
 });
 
 function leftClickEvent() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1437,8 +1437,8 @@ can-symlink@^1.0.0:
     tmp "0.0.28"
 
 caniuse-lite@^1.0.30000744:
-  version "1.0.30000747"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000747.tgz#da86e78e12d0641abeeaee6ecd55d81bd9bd3b5d"
+  version "1.0.30000748"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000748.tgz#44c8d6da52ad65a5d7b9dca4efebd0bdd982ba09"
 
 capture-exit@^1.1.0:
   version "1.2.0"
@@ -1671,10 +1671,10 @@ component-inherit@0.0.3:
   resolved "https://registry.yarnpkg.com/component-inherit/-/component-inherit-0.0.3.tgz#645fc4adf58b72b649d5cae65135619db26ff143"
 
 compressible@~2.0.11:
-  version "2.0.11"
-  resolved "https://registry.yarnpkg.com/compressible/-/compressible-2.0.11.tgz#16718a75de283ed8e604041625a2064586797d8a"
+  version "2.0.12"
+  resolved "https://registry.yarnpkg.com/compressible/-/compressible-2.0.12.tgz#c59a5c99db76767e9876500e271ef63b3493bd66"
   dependencies:
-    mime-db ">= 1.29.0 < 2"
+    mime-db ">= 1.30.0 < 2"
 
 compression@^1.4.4:
   version "1.7.1"
@@ -1951,8 +1951,8 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
 
 electron-to-chromium@^1.3.24:
-  version "1.3.26"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.26.tgz#996427294861a74d9c7c82b9260ea301e8c02d66"
+  version "1.3.27"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.27.tgz#78ecb8a399066187bb374eede35d9c70565a803d"
 
 ember-ajax@^3.0.0:
   version "3.0.0"
@@ -2323,6 +2323,12 @@ ember-router-generator@^1.0.0, ember-router-generator@^1.2.3:
   dependencies:
     recast "^0.11.3"
 
+ember-router-service-polyfill@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/ember-router-service-polyfill/-/ember-router-service-polyfill-1.0.2.tgz#6e5565f196fa7045cbe06a6fab861f9e766fe62a"
+  dependencies:
+    ember-cli-babel "^6.8.2"
+
 ember-source@~2.16.0:
   version "2.16.0"
   resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-2.16.0.tgz#2becd7966278fe453046b91178ede665c2cf241a"
@@ -2644,8 +2650,8 @@ filename-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.1.tgz#c1c4b9bee3e09725ddb106b75c1e301fe2f18b26"
 
 filesize@^3.1.3:
-  version "3.5.10"
-  resolved "https://registry.yarnpkg.com/filesize/-/filesize-3.5.10.tgz#fc8fa23ddb4ef9e5e0ab6e1e64f679a24a56761f"
+  version "3.5.11"
+  resolved "https://registry.yarnpkg.com/filesize/-/filesize-3.5.11.tgz#1919326749433bb3cf77368bd158caabcc19e9ee"
 
 fill-range@^2.1.0:
   version "2.2.3"
@@ -3855,10 +3861,10 @@ make-array@^0.1.2:
   resolved "https://registry.yarnpkg.com/make-array/-/make-array-0.1.2.tgz#335e36ebb0c5a43154d21213a1ecaeae2a1bb3ef"
 
 make-dir@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.0.0.tgz#97a011751e91dd87cfadef58832ebb04936de978"
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.1.0.tgz#19b4369fe48c116f53c2af95ad102c0e39e85d51"
   dependencies:
-    pify "^2.3.0"
+    pify "^3.0.0"
 
 makeerror@1.0.x:
   version "1.0.11"
@@ -3947,7 +3953,7 @@ micromatch@^2.1.5, micromatch@^2.3.7:
     parse-glob "^3.0.4"
     regex-cache "^0.4.2"
 
-"mime-db@>= 1.29.0 < 2", mime-db@~1.30.0:
+"mime-db@>= 1.30.0 < 2", mime-db@~1.30.0:
   version "1.30.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.30.0.tgz#74c643da2dd9d6a45399963465b26d5ca7d71f01"
 
@@ -4316,9 +4322,9 @@ performance-now@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5"
 
-pify@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
+pify@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
 
 pinkie-promise@^2.0.0:
   version "2.0.1"
@@ -4382,8 +4388,8 @@ punycode@^1.4.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
 
 q@^1.1.2:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/q/-/q-1.5.0.tgz#dd01bac9d06d30e6f219aecb8253ee9ebdc308f1"
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
 
 qs@6.5.1, qs@^6.4.0:
   version "6.5.1"
@@ -4406,8 +4412,8 @@ qunit-notifications@^0.1.1:
   resolved "https://registry.yarnpkg.com/qunit-notifications/-/qunit-notifications-0.1.1.tgz#3001afc6a6a77dfbd962ccbcddde12dec5286c09"
 
 qunitjs@^2.0.1:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/qunitjs/-/qunitjs-2.4.0.tgz#58f3a81e846687f2e7f637c5bedc9c267f887261"
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/qunitjs/-/qunitjs-2.4.1.tgz#88aba055a9e2ec3dbebfaad02471b2cb002c530b"
   dependencies:
     chokidar "1.6.1"
     commander "2.9.0"
@@ -4979,7 +4985,11 @@ stable@~0.1.3:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/stable/-/stable-0.1.6.tgz#910f5d2aed7b520c6e777499c1f32e139fdecb10"
 
-"statuses@>= 1.3.1 < 2", statuses@~1.3.1:
+"statuses@>= 1.3.1 < 2":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.4.0.tgz#bb73d446da2796106efcc1b601a253d6c46bd087"
+
+statuses@~1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.3.1.tgz#faf51b9eb74aaef3b3acf4ad5f61abf24cb7b93e"
 


### PR DESCRIPTION
now that we have https://github.com/rwjblue/ember-router-service-polyfill, we can replace some of the internal API calls with much nicer public ones.

closes https://github.com/intercom/ember-href-to/issues/82
part of https://github.com/intercom/ember-href-to/issues/88

/cc @locks @rwjblue