### PR TITLE
Transition to url without root

### DIFF
--- a/addon/href-to.js
+++ b/addon/href-to.js
@@ -28,7 +28,7 @@ export default class {
 
   handle() {
     let router = this._getRouter();
-    router.transitionTo(this.url);
+    router.transitionTo(this.getUrlWithoutRoot());
     this.event.preventDefault();
   }
 


### PR DESCRIPTION
The `ember-href-to` translates a route name correctly to an url, even if the app has a rootURL configured in the enviroment.js.

But if a transition is done with an URL, you should not include the root. Otherwise you end up with  a
> Uncaught Error: Assertion Failed: The URL '{root}/{url}' did not match any routes in your application

error.