### PR TITLE
Add support for routable engines

### DIFF
--- a/addon/helpers/href-to-external.js
+++ b/addon/helpers/href-to-external.js
@@ -1,0 +1,22 @@
+import Helper from '@ember/component/helper';
+import { getOwner } from '@ember/application';
+import { getHrefFromOwner } from './href-to';
+
+function hrefToExternal(context, targetRouteName, ...rest) {
+  const owner = getOwner(context);
+
+  if(owner.mountPoint) {
+    targetRouteName = owner._getExternalRoute(targetRouteName);
+  }
+  return getHrefFromOwner(owner, targetRouteName, ...rest);
+}
+
+export default Helper.extend({
+  compute([targetRouteName, ...rest], namedArgs) {
+    if(namedArgs.params) {
+      return hrefToExternal(this, ...namedArgs.params);
+    } else {
+      return hrefToExternal(this, targetRouteName, ...rest);
+    }
+  }
+});

--- a/addon/helpers/href-to.js
+++ b/addon/helpers/href-to.js
@@ -2,7 +2,17 @@ import Helper from "@ember/component/helper";
 import { getOwner } from "@ember/application";
 
 export function hrefTo(context, params) {
-  let routing = getOwner(context).lookup("service:-routing");
+  let owner = getOwner(context);
+  let ownerIsEngine = Boolean(owner.mountPoint)
+
+  if (ownerIsEngine && targetRouteName !== 'application') {
+    targetRouteName = `${owner.mountPoint}.${targetRouteName}`;
+  }
+  return getHrefFromOwner(owner, params);
+}
+
+export function getHrefFromOwner(owner, params) {
+  let routing = owner.lookup("service:-routing");
   return routing.generateURL(...getParamsForGenerateURL(params));
 }
 

--- a/app/helpers/href-to-external.js
+++ b/app/helpers/href-to-external.js
@@ -1,0 +1,1 @@
+export { default, hrefToExternal } from 'ember-href-to/helpers/href-to-external';


### PR DESCRIPTION
Make `{{href-to}}` act like [`{{link-to}}` does within an engine](https://github.com/ember-engines/ember-engines/blob/master/addon/components/link-to-component.js), automatically prefixing routes with the engine's namespace. 

Add `{{href-to-external}}` helper, for linking to routes in an engine's host app. Acts like [`{{link-to-external}}`](https://github.com/ember-engines/ember-engines/blob/master/addon/components/link-to-external-component.js).

This is a breaking change for anyone using `{{href-to}}` within an engine to link to routes in the host app, but that seems like an uncommon case.

I was not sure how to write tests that pretend to be in an engine, suggestions are welcome.