### PR TITLE
Fixing route recognizing logic when using hash location implementation.

### DIFF
--- a/addon/href-to.js
+++ b/addon/href-to.js
@@ -93,9 +93,26 @@ export default class {
     return this.applicationInstance.lookup('service:router');
   }
 
-  _getRootUrl() {
+  _getLocationImplementation() {
     let router = this._getRouter();
-    let rootURL = router.get('rootURL');
+
+    return router.get('location.implementation');
+  }
+
+  _getRouterRootUrl() {
+    let router = this._getRouter();
+
+    return router.get('rootURL');
+  }
+
+  _getRootUrl() {
+    let locationType = this._getLocationImplementation();
+
+    if (locationType === 'hash') {
+      return '#/';
+    }
+
+    let rootURL = this._getRouterRootUrl();
 
     if (rootURL.charAt(rootURL.length - 1) !== '/') {
       rootURL = rootURL + '/';

--- a/tests/unit/href-to-test.js
+++ b/tests/unit/href-to-test.js
@@ -107,3 +107,33 @@ test('#getUrlWithoutRoot should remove the rootUrl', function(assert) {
   hrefTo._getRootUrl = () => '/';
   assert.equal(hrefTo.getUrlWithoutRoot(), '/a/inbox', 'the url shouldn\'t include the rootUrl');
 });
+
+module('#_getRootUrl', function() {
+  test('it builds auto location roots correctly', function(assert) {
+    let event = getClickEventOnEl("<a href='/a/inbox'>");
+    let hrefTo = createHrefToForEvent(event);
+
+    hrefTo._getLocationImplementation = () => 'auto';
+    hrefTo._getRouterRootUrl = () => '/';
+
+    assert.equal(hrefTo._getRootUrl(), '/');
+
+    hrefTo._getRouterRootUrl = () => '/app';
+
+    assert.equal(hrefTo._getRootUrl(), '/app/');
+  });
+
+  test('it builds hash location roots correctly', function(assert) {
+    let event = getClickEventOnEl("<a href='/a/inbox'>");
+    let hrefTo = createHrefToForEvent(event);
+
+    hrefTo._getLocationImplementation = () => 'hash';
+    hrefTo._getRouterRootUrl = () => '/';
+
+    assert.equal(hrefTo._getRootUrl(), '#/');
+
+    hrefTo._getRouterRootUrl = () => '/app';
+
+    assert.equal(hrefTo._getRootUrl(), '#/');
+  });
+});


### PR DESCRIPTION
When using `hash` as an app's `locationType`, URLs generated by the `href-to` helper are never recognized as internal routes and are therefore never handled by click handler. This can lead to some strange behavior when using `href-to` in conjunction with other actions.