### PR TITLE
Add [data-href-to-replace] attr to use .replaceWith()

### DIFF
--- a/addon/href-to.js
+++ b/addon/href-to.js
@@ -28,7 +28,14 @@ export default class {
 
   handle() {
     let router = this._getRouter();
-    router.transitionTo(this.getUrlWithoutRoot());
+    let url = this.getUrlWithoutRoot();
+
+    if (this.isNotReplaceWithLink()) {
+      router.transitionTo(url);
+    } else {
+      router.replaceWith(url);
+    }
+
     this.event.preventDefault();
   }
 
@@ -41,6 +48,10 @@ export default class {
   hasNoTargetBlank() {
     let attr = this.target.attributes.target;
     return !attr || attr.value !== '_blank';
+  }
+
+  isNotReplaceWithLink() {
+    return !this.target.attributes["data-href-to-replace"];
   }
 
   isNotIgnored() {

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -17,6 +17,7 @@
   [<a href="{{href-to 'about'}}">About</a>]
   [<a href="{{href-to 'pages.first'}}">First Page</a>]
   [<a href="{{href-to 'pages.second'}}">Second Page</a>]
+  [<a href="{{href-to 'pages.second'}}" data-href-to-replace>Second Page (with replaceWith)</a>]
   [<a href="{{href-to params=dynamicParams}}">Second Page (with dynamic params)</a>]
   [<a href="{{href-to 'pages.second'}}"><span id="inner-span">Second Page (with inner span)</span></a>]
   [<a>An anchor with no href</a>]

--- a/tests/unit/href-to-test.js
+++ b/tests/unit/href-to-test.js
@@ -41,6 +41,20 @@ test('#isUnmodifiedLeftClick should be false for right clicks', function(assert)
   assert.notOk(hrefTo.isUnmodifiedLeftClick());
 });
 
+test('#isNotReplaceWithLink should be false if [data-href-to-replace] is present', function(assert) {
+  let event = getClickEventOnEl("<a href='' data-href-to-replace>");
+  let hrefTo = createHrefToForEvent(event);
+
+  assert.notOk(hrefTo.isNotReplaceWithLink());
+});
+
+test('#isNotReplaceWithLink should be true if [data-href-to-replace] is not present', function(assert) {
+  let event = getClickEventOnEl("<a href=''>");
+  let hrefTo = createHrefToForEvent(event);
+
+  assert.ok(hrefTo.isNotReplaceWithLink());
+});
+
 test('#isNotIgnored should be false if [data-href-to-ignore] is present', function(assert) {
   let event = getClickEventOnEl("<a href='' data-href-to-ignore>");
   let hrefTo = createHrefToForEvent(event);


### PR DESCRIPTION
Allows for replacing state instead of pushing to the history stack.

Fixes #99 