### PR TITLE
Generate the URLs using the same approach as Ember's link-to component

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "7"
+  - "6"
 
 sudo: false
 dist: trusty
@@ -13,22 +13,30 @@ cache:
   yarn: true
 
 env:
-  # we recommend new addons test the current and previous LTS
-  # as well as latest stable release (bonus points to beta/canary)
-  - EMBER_TRY_SCENARIO=ember-lts-2.8
-  - EMBER_TRY_SCENARIO=ember-lts-2.12
-  - EMBER_TRY_SCENARIO=ember-release
-  - EMBER_TRY_SCENARIO=ember-beta
-  - EMBER_TRY_SCENARIO=ember-canary
-  - EMBER_TRY_SCENARIO=ember-default
+  global:
+    # See https://git.io/vdao3 for details.
+    - JOBS=1
+  matrix:
+    # we recommend new addons test the current and previous LTS
+    # as well as latest stable release (bonus points to beta/canary)
+    - EMBER_TRY_SCENARIO=ember-lts-2.8
+    - EMBER_TRY_SCENARIO=ember-lts-2.12
+    - EMBER_TRY_SCENARIO=ember-release
+    - EMBER_TRY_SCENARIO=ember-beta
+    - EMBER_TRY_SCENARIO=ember-canary
+    - EMBER_TRY_SCENARIO=ember-default
 
 matrix:
   fast_finish: true
   allow_failures:
+    - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary
 
+before_install:
+  - curl -o- -L https://yarnpkg.com/install.sh | bash
+  - export PATH=$HOME/.yarn/bin:$PATH
+
 install:
-  - curl -o- -L https://yarnpkg.com/install.sh | bash -s
   - yarn install --no-lockfile --non-interactive
 
 script:

--- a/addon/helpers/href-to.js
+++ b/addon/helpers/href-to.js
@@ -3,8 +3,18 @@ import { getOwner } from '@ember/application';
 
 function hrefTo(context, targetRouteName, ...rest) {
   let router = getOwner(context).lookup('service:router');
+  // from https://github.com/emberjs/ember.js/blob/ad06dadce4be33db0cd74e4fd59c6dc45ceb476a/packages/%40ember/-internals/routing/lib/services/routing.ts#L45-L48
+  // similarly to Ember's internal routing service, we should return early if there's no routerMicrolib (i.e. we are rendering in an integration test)
+  if (router === undefined) {
+    return;
+  }
 
-  if(router === undefined) {
+  // from https://github.com/rwjblue/ember-router-service-polyfill/blob/82710b72d7caff1fe78b223a41ff6761d1193656/vendor/ember-router-service-polyfill/index.js#L57-L59
+  //
+  // this._router._routerMicrolib => 2.13+
+  // this._router.router => < 2.13
+  let routerMicrolib = router._router._routerMicrolib || router._router.router;
+  if (routerMicrolib === undefined) {
     return;
   }
 

--- a/tests/integration/component-test.js
+++ b/tests/integration/component-test.js
@@ -1,13 +1,8 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { getOwner } from '@ember/application';
 
 moduleForComponent('component-with-a-link', 'Integration | Component | component-with-a-link', {
   integration: true,
-
-  beforeEach() {
-    getOwner(this).lookup('router:main').setupRouter();
-  }
 });
 
 test('should change colors', function(assert) {


### PR DESCRIPTION
This will make it easier to use href-to in component integration tests.

Related to https://github.com/intercom/ember-href-to/issues/94

### Why?

`href-to` fails to execute correctly in a component integration test unless you call `.setupRouter()` beforehand
`link-to` fails to render correctly in a component integration test if you call `.setupRouter()` (and do no further setup)
This scenario works with previous versions of this add-on

### How?

Use the [same approach](https://github.com/emberjs/ember.js/blob/master/packages/@ember/-internals/glimmer/lib/components/link-to.ts#L800) that `link-to` does