### PR TITLE
Implement "ignore" environment option to blacklist catchall routes

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -2,5 +2,9 @@
 'use strict';
 
 module.exports = function(/* environment, appConfig */) {
-  return { };
+  return {
+    'ember-href-to': {
+      ignore: ['catchall']
+    }
+  };
 };

--- a/tests/acceptance/href-to-test.js
+++ b/tests/acceptance/href-to-test.js
@@ -145,3 +145,18 @@ test('The event listener does\'nt leak after the app is destroyed', function(ass
     document.body.removeEventListener('click', preventDefault);
   });
 });
+
+test('ignoring catchall route using "ember-href-to.ignore" ENV option', function(assert) {
+  visit('/about');
+
+  let preventDefault = e => e.preventDefault();
+  document.body.addEventListener('click', preventDefault);
+
+  click('a:contains(Will Not Match)');
+
+  andThen(function() {
+    document.body.removeEventListener('click', preventDefault);
+
+    assert.equal(currentURL(), '/about');
+  });
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -12,6 +12,7 @@ Router.map(function() {
     this.route('first');
     this.route('second');
   });
+  this.route('catchall', { path: "/*" });
 });
 
 export default Router;

--- a/tests/dummy/app/templates/about.hbs
+++ b/tests/dummy/app/templates/about.hbs
@@ -23,3 +23,6 @@ Section: {{section}}
 <br />
 Action: <a href="#" {{action "increment"}}>Increment</a> <span id="count">{{count}}</span>
 <br />
+<br />
+Ignore catchall route: <a href="/about/will-not-match">Will Not Match</a>
+<br />Use <code>'ember-href-to': { ignore: ['catchall'] }</code> in environment.js.

--- a/tests/unit/href-to-test.js
+++ b/tests/unit/href-to-test.js
@@ -9,7 +9,8 @@ function createHrefToForEvent(event) {
   let mockApplicationInstance = {
     lookup() {
       return viewRegistry;
-    }
+    },
+    resolveRegistration() {}
   };
 
   return new HrefTo(mockApplicationInstance, event);


### PR DESCRIPTION
```
// config/environment.js
'ember-href-to': {
  ignore: ['catchall']
}
```

It is useful when you have mixed client-side and server-side routing along with catchall route, and you don't want or can't use `data-href-to-ignore` attribute.