### PR TITLE
flatten array of models

### DIFF
--- a/addon/helpers/href-to.js
+++ b/addon/helpers/href-to.js
@@ -16,7 +16,7 @@ function getParamsForGenerateURL(params) {
   } else {
     queryParams = {};
   }
-  let models = params; // the remainder are the models
+  let models = params.flat(); // the remainder are the models
   return [targetRouteName, models, queryParams];
 }
 


### PR DESCRIPTION
Hello, great addon! We use it heavily at [Prysmex](https://prysmex.com/?lang=en)

This PR is simple, just allow positional models params to be an array and flatten the array before creating the url, mostly to make it compatible with the new api of `<LinkTo />`

A whole new pattern opened to us... passing array of models instead of positionally passing models

So we went from simple classic:
/some/route/{type}/{id}

```hbs
{{link-to "some.route" model.type model.id}}
```

To every model knowing how to go to their show like this.

```ts
export default class SomeModel extends Model {

  showRoutePath = "some.route";

  get showRouteSegments() {
     return [this.type, this.id]
  } 

  get showRoute() {
      return {
        route: this.showRoutePath,
        models: this.showRouteSegments
     }
   }
}
```
And consume in a very dynamic manner in templates like this
```hbs
<LinkTo @route={{@model.showRoute.route}} @models={{@model.showRoute.models}} />
```

With this flattening now we can use
```hbs
<SomeButtonComponent @link={{href-to @model.showRoute.route @model.showRoute.models}} />
```
