### PR TITLE
Bump Node.js version to 8 in .travis.yaml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "6"
+  - "8"
 
 sudo: false
 dist: trusty


### PR DESCRIPTION
Bump Node.js version to 8 in .travis.yaml, where some transitive dependencies do not support Node.js 6.