### PR TITLE
Dont trigger element handler when it doesn't exist

### DIFF
--- a/app/instance-initializers/ember-href-to.js
+++ b/app/instance-initializers/ember-href-to.js
@@ -18,7 +18,7 @@ export default {
     if (typeof(FastBoot) === "undefined") {
       let hrefToClickHandler = function _hrefToClickHandler(e) {
         let link = e.target.tagName === 'A' ? e.target : closestLink(e.target);
-        if (link) {
+        if (link && document.body.contains(link)) {
           let hrefTo = new HrefTo(applicationInstance, e, link);
           hrefTo.maybeHandle();
         }


### PR DESCRIPTION
In our project, sometimes navigation would end up where we didn't expect.
It turns out that sometimes the href-to document handler picks up and reacts to a click event when it shouldn't.
Testing that the element being responded to still exists in the DOM fixed it for us.