### PR TITLE
release 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-href-to",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "description": "A lightweight alternative to `{{link-to}}`",
   "scripts": {
     "lint:hbs": "ember-template-lint .",


### PR DESCRIPTION
Includes https://github.com/intercom/ember-href-to/pull/132 which fixes https://github.com/intercom/ember-href-to/issues/131. Thanks @jordpo!

This change relies on Ember 3.6+ so I'm bumping the version number to `4.0.0`.
