### PR TITLE
don't subscribe to `routeDidChange` if the router service is a mock

### DIFF
--- a/addon/helpers/href-to.js
+++ b/addon/helpers/href-to.js
@@ -30,7 +30,10 @@ export default class HrefToHelper extends Helper {
 
   init() {
     super.init();
-    this.router.on('routeDidChange', this.recompute.bind(this));
+
+    if (this.router && this.router.on) { // skip if the router service is mocked
+      this.router.on("routeDidChange", this.recompute.bind(this));
+    }
   }
 
   compute(params, namedArgs) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-href-to",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "A lightweight alternative to `{{link-to}}`",
   "scripts": {
     "lint:hbs": "ember-template-lint .",


### PR DESCRIPTION
When I tried to upgrade to `4.0.0`, I noticed some `this.router.on is not a function` test failures due to using a mocked router service. This guard prevents `routeDidChange` subscription if the router doesn't have an `on` method

