### PR TITLE
do not rely on ember-legacy-built-in-components

### DIFF
--- a/addon/href-to.js
+++ b/addon/href-to.js
@@ -1,5 +1,3 @@
-import { LinkComponent } from '@ember/legacy-built-in-components';
-
 export default class {
 
   constructor(applicationInstance, event, target = event.target) {
@@ -60,7 +58,7 @@ export default class {
     let id = this.target.id;
     if (id) {
       let componentInstance = this.applicationInstance.lookup('-view-registry:main')[id];
-      isLinkComponent = componentInstance && componentInstance instanceof LinkComponent;
+      isLinkComponent = componentInstance && componentInstance.constructor.superclass.toString() === '@ember/routing/link-component';
     }
 
     return !isLinkComponent;

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "devDependencies": {
     "@ember/jquery": "^1.1.0",
+    "@ember/legacy-built-in-components": "^0.4.0",
     "@ember/optional-features": "^1.3.0",
     "@embroider/test-setup": "0.33.0",
     "broccoli-asset-rev": "^3.0.0",
@@ -53,7 +54,6 @@
     "test": "tests"
   },
   "dependencies": {
-    "@ember/legacy-built-in-components": "^0.4.0",
     "ember-cli-babel": "^7.13.2"
   },
   "ember-addon": {

--- a/tests/dummy/app/components/a-subclass-link.js
+++ b/tests/dummy/app/components/a-subclass-link.js
@@ -1,0 +1,16 @@
+import ALink from './a-link';
+
+let LinkClass = ALink.extend({
+});
+
+LinkClass = LinkClass.extend({
+});
+
+LinkClass = LinkClass.extend({
+});
+
+LinkClass = LinkClass.extend({
+});
+
+
+export default LinkClass;

--- a/tests/integration/href-to-test.js
+++ b/tests/integration/href-to-test.js
@@ -34,4 +34,14 @@ module('Integration | HrefTo', function(hooks) {
     let hrefTo = new HrefTo(this.owner, event);
     assert.notOk(hrefTo.isNotLinkComponent());
   });
+
+  test(`#isNotLinkComponent should be false if the event target is an instance of Em.LinkComponent (subclass)`, async function(assert) {
+    await render(hbs`{{a-subclass-link 'about' 'about' class='a-link'}}`);
+
+    let event = leftClickEvent();
+    event.target = find('.a-link');
+
+    let hrefTo = new HrefTo(this.owner, event);
+    assert.notOk(hrefTo.isNotLinkComponent());
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1929,11 +1929,11 @@
     resolve "^1.11.1"
 
 "@ember/legacy-built-in-components@^0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@ember/legacy-built-in-components/-/legacy-built-in-components-0.4.0.tgz#23d61c9220c04d3590644ffe427cc987db4880a7"
-  integrity sha512-nm0tTe9d7aYpPa8sk85M4AZ3iDfuVQ4/7M4D4IdI7frkAOGpy6gAKS9nR/UR8mJDW06CLz9NYEKWIlLopEu/Og==
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/@ember/legacy-built-in-components/-/legacy-built-in-components-0.4.2.tgz#79a97d66153ff17909759b368b2a117bc9e168e5"
+  integrity sha512-rJulbyVQIVe1zEDQDqAQHechHy44DsS2qxO24+NmU/AYxwPFSzWC/OZNCDFSfLU+Y5BVd/00qjxF0pu7Nk+TNA==
   dependencies:
-    "@embroider/macros" "^0.47.1"
+    "@embroider/macros" "^1.0.0"
     ember-cli-babel "^7.26.6"
     ember-cli-htmlbars "^5.7.1"
     ember-cli-typescript "^4.1.0"
@@ -1963,27 +1963,29 @@
     ember-cli-htmlbars-inline-precompile "^2.1.0"
     ember-test-waiters "^1.1.1"
 
-"@embroider/macros@^0.47.1":
-  version "0.47.2"
-  resolved "https://registry.yarnpkg.com/@embroider/macros/-/macros-0.47.2.tgz#23cbe92cac3c24747f054e1eea2a22538bf7ebd0"
-  integrity sha512-ViNWluJCeM5OPlM3rs8kdOz3RV5rpfXX5D2rDnc/q86xRS0xf4NFEjYRV7W6fBcD0b3v5jSHDTwrjq9Kee4rHg==
+"@embroider/macros@^1.0.0":
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/@embroider/macros/-/macros-1.10.0.tgz#af3844d5db48f001b85cfb096c76727c72ad6c1e"
+  integrity sha512-LMbfQGk/a+f6xtvAv5fq/wf2LRxETnbgSCLUf/z6ebzmuskOUxrke+uP55chF/loWrARi9g6erFQ7RDOUoBMSg==
   dependencies:
-    "@embroider/shared-internals" "0.47.2"
+    "@embroider/shared-internals" "2.0.0"
     assert-never "^1.2.1"
+    babel-import-util "^1.1.0"
     ember-cli-babel "^7.26.6"
     find-up "^5.0.0"
     lodash "^4.17.21"
     resolve "^1.20.0"
     semver "^7.3.2"
 
-"@embroider/shared-internals@0.47.2":
-  version "0.47.2"
-  resolved "https://registry.yarnpkg.com/@embroider/shared-internals/-/shared-internals-0.47.2.tgz#24e9fa0dd9c529d5c996ee1325729ea08d1fa19f"
-  integrity sha512-SxdZYjAE0fiM5zGDz+12euWIsQZ1tsfR1k+NKmiWMyLhA5T3pNgbR2/Djvx/cVIxOtEavGGSllYbzRKBtV4xMg==
+"@embroider/shared-internals@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@embroider/shared-internals/-/shared-internals-2.0.0.tgz#d8205ec6944362aeecfbb51143db352430ced316"
+  integrity sha512-qZ2/xky9mWm5YC6noOa6AiAwgISEQ78YTZNv4SNu2PFgEK/H+Ha/3ddngzGSsnXkVnIHZyxIBzhxETonQYHY9g==
   dependencies:
-    babel-import-util "^0.2.0"
+    babel-import-util "^1.1.0"
     ember-rfc176-data "^0.3.17"
     fs-extra "^9.1.0"
+    js-string-escape "^1.0.1"
     lodash "^4.17.21"
     resolve-package-path "^4.0.1"
     semver "^7.3.5"
@@ -2742,10 +2744,10 @@ babel-helpers@^6.24.1:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
-babel-import-util@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/babel-import-util/-/babel-import-util-0.2.0.tgz#b468bb679919601a3570f9e317536c54f2862e23"
-  integrity sha512-CtWYYHU/MgK88rxMrLfkD356dApswtR/kWZ/c6JifG1m10e7tBBrs/366dFzWMAoqYmG5/JSh+94tUSpIwh+ag==
+babel-import-util@^1.1.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/babel-import-util/-/babel-import-util-1.3.0.tgz#dc9251ea39a7747bd586c1c13b8d785a42797f8e"
+  integrity sha512-PPzUT17eAI18zn6ek1R3sB4Krc/MbnmT1MkZQFmyhjoaEGBVwNABhfVU9+EKcDSKrrOm9OIpGhjxukx1GCiy1g==
 
 babel-messages@^6.23.0:
   version "6.23.0"
@@ -7790,6 +7792,11 @@ js-reporters@1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/js-reporters/-/js-reporters-1.2.1.tgz#f88c608e324a3373a95bcc45ad305e5c979c459b"
   integrity sha1-+IxgjjJKM3OpW8xFrTBeXJecRZs=
+
+js-string-escape@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/js-string-escape/-/js-string-escape-1.0.1.tgz#e2625badbc0d67c7533e9edc1068c587ae4137ef"
+  integrity sha512-Smw4xcfIQ5LVjAOuJCvN/zIodzA/BBSsluuoSykP+lUvScIi4U6RJLfwHet5cxFnCswUjISV8oAXaqaJDY3chg==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
I was wondering why ember-href-to was depending on `@ember/legacy-built-in-components`.
Turns out it was only for testing if the link isn't an instance of the LinkComponent.

With this approach, I test if the component is an instance of LinkComponent using its `toString()` method.

LinkComponent defines a `toString()` that outputs `@ember/routing/link-component` since version `3.1.0` (released on 13 Apr 2018): https://github.com/emberjs/ember.js/blob/v3.1.0/packages/ember-glimmer/lib/components/link-to.ts#L825

But why?
Well, first we would be avoiding installing stuff we don't need and the user doesn't use.
And also, `@ember/legacy-built-in-components` seems a bit unmaintained and still prints embroider warnings, which might throw new users off for this addon: https://github.com/emberjs/ember-legacy-built-in-components/issues/18

I added a new test case just to make sure that it works with several levels of subclassing of the LinkComponent.
