### PR TITLE
Support Glimmer's LinkTo components as well

### DIFF
--- a/addon/href-to.js
+++ b/addon/href-to.js
@@ -60,7 +60,7 @@ export default class {
     let id = this.target.id;
     if (id) {
       let componentInstance = this.applicationInstance.lookup('-view-registry:main')[id];
-      isLinkComponent = componentInstance && componentInstance instanceof LinkComponent;
+      isLinkComponent = componentInstance && (componentInstance instanceof LinkComponent || componentInstance.constructor.toString() === "@ember/routing/link-component");
     }
 
     return !isLinkComponent;

--- a/tests/integration/href-to-test.js
+++ b/tests/integration/href-to-test.js
@@ -34,4 +34,14 @@ module('Integration | HrefTo', function(hooks) {
     let hrefTo = new HrefTo(this.owner, event);
     assert.notOk(hrefTo.isNotLinkComponent());
   });
+
+  test(`#isNotLinkComponent should be false if the event target is an instance of Glimmer's LinkComponent`, async function(assert) {
+    await render(hbs`<LinkTo @route='about' class='a-glimmer-link'>about</LinkTo>}}`);
+
+    let event = leftClickEvent();
+    event.target = find(".a-glimmer-link");
+
+    let hrefTo = new HrefTo(this.owner, event);
+    assert.notOk(hrefTo.isNotLinkComponent());
+  });
 });


### PR DESCRIPTION
Had some weird bugs in our app until we found this issue where `isLinkComponent` is false even if it is a real LinkTo component. Seems like the inheritance chain for LinkTo components has changed and it doesn't work to compare with the class from `legacy-built-in-components`.

My fix was the quickest solution I could think of, there is probably a better/nicer solution you could implement to fix the test I added.